### PR TITLE
Fixes `executionData` file getting overridden

### DIFF
--- a/src/main/kotlin/pl/droidsonroids/gradle/jacoco/testkit/JacocoTestKitExtension.kt
+++ b/src/main/kotlin/pl/droidsonroids/gradle/jacoco/testkit/JacocoTestKitExtension.kt
@@ -5,6 +5,7 @@ import org.gradle.api.Task
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
+import org.gradle.testing.jacoco.tasks.JacocoReport
 import java.io.File
 
 open class JacocoTestKitExtension(private val project: Project) {
@@ -12,21 +13,28 @@ open class JacocoTestKitExtension(private val project: Project) {
 
     fun applyTo(configurationRuntime: String, taskProvider: TaskProvider<Task>) {
         with(project) {
+            val destinationFile = taskProvider.map { task ->
+                val extension = task.extensions.getByType(JacocoTaskExtension::class.java)
+                val file = checkNotNull(extension.destinationFile) { "destinationFile is missing on task $name jacoco extension" }
+
+                File(file.parentFile, "${file.nameWithoutExtension}-gradle-runner.${file.extension}")
+            }
+
             val jacocoTestKitPropertiesTask = tasks.register(
                 generatePropertiesTaskName(taskProvider.name),
                 GenerateJaCoCoTestKitProperties::class.java
             ) {
                 it.outputFile = File(buildDir, "testkit/${taskProvider.name}/testkit-gradle.properties")
-                it.destinationFile.set(
-                    taskProvider.map {
-                        task -> task.extensions.getByType(JacocoTaskExtension::class.java).destinationFile!!.path
-                    }.get()
-                )
+                it.destinationFile.set(destinationFile.get().path)
                 it.jacocoRuntimePath.set(jacocoRuntimePathProvider)
             }
 
             dependencies.add(configurationRuntime, files(testKitDir(taskProvider.name)))
             taskProvider.configure { it.dependsOn(jacocoTestKitPropertiesTask) }
+
+            tasks.withType(JacocoReport::class.java)
+                .matching { it.name == "jacoco${taskProvider.name.capitalize()}Report" }
+                .all { it.executionData(destinationFile) }
         }
     }
 

--- a/src/test/kotlin/pl/droidsonroids/gradle/jacoco/testkit/JaCoCoTestKitPluginFunctionalTest.kt
+++ b/src/test/kotlin/pl/droidsonroids/gradle/jacoco/testkit/JaCoCoTestKitPluginFunctionalTest.kt
@@ -38,7 +38,7 @@ class JaCoCoTestKitPluginFunctionalTest {
                 .startsWith("\"-javaagent:")
                 .contains("=destfile=")
                 .contains(JacocoPlugin.DEFAULT_JACOCO_VERSION)
-                .endsWith("test.exec\"")
+                .endsWith("test-gradle-runner.exec\"")
     }
 
     @Test
@@ -119,7 +119,7 @@ class JaCoCoTestKitPluginFunctionalTest {
 
         val args = readArgsFromProperties()
         assertThat(args)
-                .endsWith("integration.exec\"")
+                .endsWith("integration-gradle-runner.exec\"")
     }
 
     @Test
@@ -134,7 +134,7 @@ class JaCoCoTestKitPluginFunctionalTest {
 
         val args = readArgsFromProperties("integrationTest")
         assertThat(args)
-            .endsWith("integrationTest.exec\"")
+            .endsWith("integrationTest-gradle-runner.exec\"")
     }
 
     private fun readArgsFromProperties(taskName: String = "test"): String {


### PR DESCRIPTION
This PR addresses the being discussed here https://github.com/gradle/gradle/issues/16603#issuecomment-879024961 regarding Gradle's Build Cache failing to pack an entry.

The root cause is a race condition caused by this plugin, because the execution data is getting feed (and overridden) by two Jacoco agents: the one from the `Test` class and the other one that runs inside it with a `GradleRunner`.

The fixing approach is to create a companion execution data file and make it's associated `JacocoReport` task to also feed from it.