### PR TITLE
Revert PR-21 fix execution data clash

### DIFF
--- a/src/main/kotlin/pl/droidsonroids/gradle/jacoco/testkit/JaCoCoTestKitPlugin.kt
+++ b/src/main/kotlin/pl/droidsonroids/gradle/jacoco/testkit/JaCoCoTestKitPlugin.kt
@@ -11,6 +11,8 @@ class JaCoCoTestKitPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
         with(project) {
+            pluginManager.apply("jacoco")
+
             val extension = extensions.create("jacocoTestKit", JacocoTestKitExtension::class.java, project)
             configurations.maybeCreate(jacocoRuntime)
                     .setVisible(false)

--- a/src/main/kotlin/pl/droidsonroids/gradle/jacoco/testkit/JacocoTestKitExtension.kt
+++ b/src/main/kotlin/pl/droidsonroids/gradle/jacoco/testkit/JacocoTestKitExtension.kt
@@ -5,7 +5,6 @@ import org.gradle.api.Task
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
-import org.gradle.testing.jacoco.tasks.JacocoReport
 import java.io.File
 
 open class JacocoTestKitExtension(private val project: Project) {
@@ -13,28 +12,21 @@ open class JacocoTestKitExtension(private val project: Project) {
 
     fun applyTo(configurationRuntime: String, taskProvider: TaskProvider<Task>) {
         with(project) {
-            val destinationFile = taskProvider.map { task ->
-                val extension = task.extensions.getByType(JacocoTaskExtension::class.java)
-                val file = checkNotNull(extension.destinationFile) { "destinationFile is missing on task $name jacoco extension" }
-
-                File(file.parentFile, "${file.nameWithoutExtension}-gradle-runner.${file.extension}")
-            }
-
             val jacocoTestKitPropertiesTask = tasks.register(
                 generatePropertiesTaskName(taskProvider.name),
                 GenerateJaCoCoTestKitProperties::class.java
             ) {
                 it.outputFile = File(buildDir, "testkit/${taskProvider.name}/testkit-gradle.properties")
-                it.destinationFile.set(destinationFile.get().path)
+                it.destinationFile.set(
+                    taskProvider.map {
+                        task -> task.extensions.getByType(JacocoTaskExtension::class.java).destinationFile!!.path
+                    }.get()
+                )
                 it.jacocoRuntimePath.set(jacocoRuntimePathProvider)
             }
 
             dependencies.add(configurationRuntime, files(testKitDir(taskProvider.name)))
             taskProvider.configure { it.dependsOn(jacocoTestKitPropertiesTask) }
-
-            tasks.withType(JacocoReport::class.java)
-                .matching { it.name == "jacoco${taskProvider.name.capitalize()}Report" }
-                .all { it.executionData(destinationFile) }
         }
     }
 

--- a/src/test/kotlin/pl/droidsonroids/gradle/jacoco/testkit/JaCoCoTestKitPluginFunctionalTest.kt
+++ b/src/test/kotlin/pl/droidsonroids/gradle/jacoco/testkit/JaCoCoTestKitPluginFunctionalTest.kt
@@ -38,7 +38,7 @@ class JaCoCoTestKitPluginFunctionalTest {
                 .startsWith("\"-javaagent:")
                 .contains("=destfile=")
                 .contains(JacocoPlugin.DEFAULT_JACOCO_VERSION)
-                .endsWith("test-gradle-runner.exec\"")
+                .endsWith("test.exec\"")
     }
 
     @Test
@@ -119,7 +119,7 @@ class JaCoCoTestKitPluginFunctionalTest {
 
         val args = readArgsFromProperties()
         assertThat(args)
-                .endsWith("integration-gradle-runner.exec\"")
+                .endsWith("integration.exec\"")
     }
 
     @Test
@@ -134,7 +134,7 @@ class JaCoCoTestKitPluginFunctionalTest {
 
         val args = readArgsFromProperties("integrationTest")
         assertThat(args)
-            .endsWith("integrationTest-gradle-runner.exec\"")
+            .endsWith("integrationTest.exec\"")
     }
 
     private fun readArgsFromProperties(taskName: String = "test"): String {


### PR DESCRIPTION
Reverts https://github.com/koral--/jacoco-gradle-testkit-plugin/pull/21 because the new file was issues with `Gradle Build Cache` when the `Test` stask is not executed with `FROM-CACHE` result.
Full reason here: https://github.com/koral--/jacoco-gradle-testkit-plugin/pull/21#issuecomment-884336914

Plus, the assumption that the `test.exec` file was overridden was incorrect, as it's clary stated here:
> The JaCoCo agent supports writing in parallel to the same file
https://github.com/gradle/gradle/blob/master/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java#L196

The only valid workaround I've found for the issue raised in https://github.com/gradle/gradle/issues/16603#issuecomment-879024961 was to add a this to our build logic:
```kotlin
    tasks.withType<Test> {
        doLast { sleep(1000) } // sometimes it throws Unable to read execution data file
    }
```
I think a ticket should be raised (if there isn't any already) to Gradle team asking a correct finishing of the `GradleRunner` JVM before ending the test to make sure it's not altering the `test.exec` once the `Test` task has finished.

Also, I addressed this https://github.com/koral--/jacoco-gradle-testkit-plugin/issues/22 (1 line of code)