### PR TITLE
Restore Java 8 compatibility + update Configuration-cache tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ for more details.
 - Apply plugin in `build.gradle`:
 ```groovy
 plugins {
-  id "pl.droidsonroids.jacoco.testkit" version "1.0.9"
+  id "pl.droidsonroids.jacoco.testkit" version "1.0.10"
 }
 ```
 This will add `testkit-gradle.properties` system resource.
@@ -74,4 +74,6 @@ tasks.named("test").configure {
 ```
 
 ### Requirements
-Minimum supported Gradle version is 7.6
+Minimum supported versions:
+- Gradle: **7.6**
+- Java: **1.8**

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'com.gradle.plugin-publish' version '1.2.0'
     id 'jacoco'
     id 'java-gradle-plugin'
-    id 'pl.droidsonroids.jacoco.testkit' version '1.0.10'
+//    id 'pl.droidsonroids.jacoco.testkit' version '1.0.8'
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.8.20'
     id 'com.gradle.plugin-publish' version '1.2.0'
@@ -32,6 +34,14 @@ gradlePlugin {
 
 kotlin {
     jvmToolchain(17)
+}
+
+def javaTargetVersion = JavaVersion.VERSION_1_8
+tasks.withType(KotlinCompile).configureEach {
+    kotlinOptions.jvmTarget = javaTargetVersion.toString()
+}
+tasks.withType(JavaCompile).configureEach {
+    options.release.set(javaTargetVersion.majorVersion.toInteger())
 }
 
 jacoco {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 dependencies {
     compileOnly gradleApi()
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.assertj:assertj-core:3.16.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 }
 
 group = GROUP

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'com.gradle.plugin-publish' version '1.2.0'
     id 'jacoco'
     id 'java-gradle-plugin'
-//    id 'pl.droidsonroids.jacoco.testkit' version '1.0.8'
+    id 'pl.droidsonroids.jacoco.testkit' version '1.0.10'
 }
 
 dependencies {

--- a/src/test/kotlin/pl/droidsonroids/gradle/jacoco/testkit/JaCoCoTestKitPluginFunctionalTest.kt
+++ b/src/test/kotlin/pl/droidsonroids/gradle/jacoco/testkit/JaCoCoTestKitPluginFunctionalTest.kt
@@ -17,7 +17,7 @@ class JaCoCoTestKitPluginFunctionalTest {
 
     @Before
     fun setUp() {
-        temporaryFolder.newFile("gradle.properties").fillFromResource("testkit-gradle.properties")
+        temporaryFolder.newFile("gradle.properties")
     }
 
     companion object {

--- a/src/test/kotlin/pl/droidsonroids/gradle/jacoco/testkit/JaCoCoTestKitPluginFunctionalTest.kt
+++ b/src/test/kotlin/pl/droidsonroids/gradle/jacoco/testkit/JaCoCoTestKitPluginFunctionalTest.kt
@@ -17,7 +17,7 @@ class JaCoCoTestKitPluginFunctionalTest {
 
     @Before
     fun setUp() {
-        temporaryFolder.newFile("gradle.properties")
+        temporaryFolder.newFile("gradle.properties").fillFromResource("testkit-gradle.properties")
     }
 
     companion object {


### PR DESCRIPTION
I realized I accidentally raised min java requirement to Java 17 (by setting JVM toolchain). ~I didn't know which Java version the plugin was compatible with previously, so I'm proposing to bring back _a reasonable_ requirement of Java 11.~ 
The CI tested the plugin against Java 8 👀 

~In addition, I'm fixing code coverage, which I commented out to let the plugin compile again, tested locally produces _valid_ report:~
<img width="1108" alt="image" src="https://user-images.githubusercontent.com/36954793/232840173-e98d4fae-43fc-4e60-b20f-838eb68f8634.png">

To make the CI pass it's required to bring back Java 8 compatibility first (or upgrade CI's java to 17)